### PR TITLE
Fix a type error and an error to sendStatus() multiple times

### DIFF
--- a/lib/sounds.js
+++ b/lib/sounds.js
@@ -10,9 +10,10 @@ function play(file)
   {
     player.play(file, (function (err) {
       if (err) {
-        res.setHeater('Content-Type', 'application/json');
+        res.setHeader('Content-Type', 'application/json');
         res.status(500).send(JSON.stringify(err));
         console.error(err);
+        return;
       }
 
       res.sendStatus(204);


### PR DESCRIPTION
`setHeater()` -> `setHeader()`, small typo :)

The `return` in the error check was added because without it, if an error occurs, this exception is thrown.

```
Error: Can't set headers after they are sent.
```